### PR TITLE
Update BridgeExecutorBase.sol: Enhanced Modifier 'onlyThis'

### DIFF
--- a/src/executors/BridgeExecutorBase.sol
+++ b/src/executors/BridgeExecutorBase.sol
@@ -11,7 +11,7 @@ import {IExecutorBase} from '../interfaces/IExecutorBase.sol';
  * contract with proper access control
  */
 abstract contract BridgeExecutorBase is IExecutorBase {
-  // Minimum allowed grace period, which reduces the risk of having an actions set expire due to network congestion
+  // Minimum allowed grace period, which reduces the risk of having an action set expire due to network congestion
   uint256 constant MINIMUM_GRACE_PERIOD = 10 minutes;
 
   // Time between queuing and execution
@@ -44,7 +44,7 @@ abstract contract BridgeExecutorBase is IExecutorBase {
    * @dev Only this contract can call functions marked by this modifier.
    **/
   modifier onlyThis() {
-    if (msg.sender != address(this)) revert OnlyCallableByThis();
+    _check();
     _;
   }
 
@@ -78,6 +78,11 @@ abstract contract BridgeExecutorBase is IExecutorBase {
     _updateGuardian(guardian);
   }
 
+  /// @dev internal function used by the modifier onlyThis
+  function _check() internal view {
+    if (msg.sender != address(this)) revert OnlyCallableByThis();
+  }
+
   /// @inheritdoc IExecutorBase
   function execute(uint256 actionsSetId) external payable override {
     if (getCurrentState(actionsSetId) != ActionsSetState.Queued) revert OnlyQueuedActions();
@@ -89,7 +94,7 @@ abstract contract BridgeExecutorBase is IExecutorBase {
     uint256 actionCount = actionsSet.targets.length;
 
     bytes[] memory returnedData = new bytes[](actionCount);
-    for (uint256 i = 0; i < actionCount; ) {
+    for (uint256 i; i < actionCount; ) {
       returnedData[i] = _executeTransaction(
         actionsSet.targets[i],
         actionsSet.values[i],
@@ -114,7 +119,7 @@ abstract contract BridgeExecutorBase is IExecutorBase {
     actionsSet.canceled = true;
 
     uint256 targetsLength = actionsSet.targets.length;
-    for (uint256 i = 0; i < targetsLength; ) {
+    for (uint256 i; i < targetsLength; ) {
       _cancelTransaction(
         actionsSet.targets[i],
         actionsSet.values[i],
@@ -296,7 +301,7 @@ abstract contract BridgeExecutorBase is IExecutorBase {
       ++_actionsSetCounter;
     }
 
-    for (uint256 i = 0; i < targetsLength; ) {
+    for (uint256 i; i < targetsLength; ) {
       bytes32 actionHash = keccak256(
         abi.encode(
           targets[i],


### PR DESCRIPTION
This PR aims for two changes:
1. Using an internal function for the modifier `onlyThis` which is used like 5 times. It's always advisable to use internal functions with these modifiers who are used most often in a code. Refer this for a good explanation: https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#use-internal-view-functions-in-modifiers-to-save-bytecode
2. Liked the way, 'for' loops are derived in this codebase. Changing `uint256 i = 0;` to `uint256 i;` gives it a final touch. This might help -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#for-loops-improvement

Thanks!