### PR TITLE
[SC-429] Remove min and max delay

### DIFF
--- a/src/executors/AuthBridgeExecutor.sol
+++ b/src/executors/AuthBridgeExecutor.sol
@@ -19,22 +19,16 @@ contract AuthBridgeExecutor is IAuthBridgeExecutor, AccessControl, BridgeExecuto
      *
      * @param delay The delay before which an actions set can be executed
      * @param gracePeriod The time period after a delay during which an actions set can be executed
-     * @param minimumDelay The minimum bound a delay can be set to
-     * @param maximumDelay The maximum bound a delay can be set to
      * @param guardian The address of the guardian, which can cancel queued proposals (can be zero)
      */
     constructor(
         uint256 delay,
         uint256 gracePeriod,
-        uint256 minimumDelay,
-        uint256 maximumDelay,
         address guardian
     )
         BridgeExecutorBase(
             delay,
             gracePeriod,
-            minimumDelay,
-            maximumDelay,
             guardian
         )
     {

--- a/src/interfaces/IExecutorBase.sol
+++ b/src/interfaces/IExecutorBase.sol
@@ -116,20 +116,6 @@ interface IExecutorBase {
     event GracePeriodUpdate(uint256 oldGracePeriod, uint256 newGracePeriod);
 
     /**
-     * @dev Emitted when the minimum delay (lower bound of delay) is updated
-     * @param oldMinimumDelay The value of the old minimum delay
-     * @param newMinimumDelay The value of the new minimum delay
-     **/
-    event MinimumDelayUpdate(uint256 oldMinimumDelay, uint256 newMinimumDelay);
-
-    /**
-     * @dev Emitted when the maximum delay (upper bound of delay)is updated
-     * @param oldMaximumDelay The value of the old maximum delay
-     * @param newMaximumDelay The value of the new maximum delay
-     **/
-    event MaximumDelayUpdate(uint256 oldMaximumDelay, uint256 newMaximumDelay);
-
-    /**
      * @notice Execute the ActionsSet
      * @param actionsSetId The id of the ActionsSet to execute
      **/
@@ -161,18 +147,6 @@ interface IExecutorBase {
     function updateGracePeriod(uint256 gracePeriod) external;
 
     /**
-     * @notice Update the minimum allowed delay
-     * @param minimumDelay The value of the minimum delay (in seconds)
-     **/
-    function updateMinimumDelay(uint256 minimumDelay) external;
-
-    /**
-     * @notice Update the maximum allowed delay
-     * @param maximumDelay The maximum delay (in seconds)
-     **/
-    function updateMaximumDelay(uint256 maximumDelay) external;
-
-    /**
      * @notice Allows to delegatecall a given target with an specific amount of value
      * @dev This function is external so it allows to specify a defined msg.value for the delegate call, reducing
      * the risk that a delegatecall gets executed with more value than intended
@@ -201,18 +175,6 @@ interface IExecutorBase {
      * @return The value of the grace period (in seconds)
      **/
     function getGracePeriod() external view returns (uint256);
-
-    /**
-     * @notice Returns the minimum delay
-     * @return The value of the minimum delay (in seconds)
-     **/
-    function getMinimumDelay() external view returns (uint256);
-
-    /**
-     * @notice Returns the maximum delay
-     * @return The value of the maximum delay (in seconds)
-     **/
-    function getMaximumDelay() external view returns (uint256);
 
     /**
      * @notice Returns the address of the guardian

--- a/test/ArbitrumOneCrosschainTest.t.sol
+++ b/test/ArbitrumOneCrosschainTest.t.sol
@@ -46,8 +46,6 @@ contract ArbitrumOneCrosschainTest is CrosschainTestBase {
         bridgeExecutor = new AuthBridgeExecutor(
             defaultL2BridgeExecutorArgs.delay,
             defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.minimumDelay,
-            defaultL2BridgeExecutorArgs.maximumDelay,
             defaultL2BridgeExecutorArgs.guardian
         );
         bridgeReceiver = address(new BridgeExecutorReceiverArbitrum(

--- a/test/AuthBridgeExecutor.t.sol
+++ b/test/AuthBridgeExecutor.t.sol
@@ -68,8 +68,6 @@ contract AuthBridgeExecutorTestBase is Test {
         executor = new AuthBridgeExecutor({
             delay:        DELAY,
             gracePeriod:  GRACE_PERIOD,
-            minimumDelay: 0,         // TODO: removing this in next PR
-            maximumDelay: 365 days,  // TODO: removing this in next PR
             guardian:     guardian
         });
         executor.grantRole(executor.AUTHORIZED_BRIDGE_ROLE(), bridge);
@@ -160,16 +158,12 @@ contract AuthBridgeExecutorConstructorTests is AuthBridgeExecutorTestBase {
         executor = new AuthBridgeExecutor({
             delay:        DELAY,
             gracePeriod:  10 minutes - 1,
-            minimumDelay: 0,
-            maximumDelay: 365 days,
             guardian:     guardian
         });
 
         executor = new AuthBridgeExecutor({
             delay:        DELAY,
             gracePeriod:  10 minutes,
-            minimumDelay: 0,
-            maximumDelay: 365 days,
             guardian:     guardian
         });
     }
@@ -184,8 +178,6 @@ contract AuthBridgeExecutorConstructorTests is AuthBridgeExecutorTestBase {
         executor = new AuthBridgeExecutor({
             delay:        DELAY,
             gracePeriod:  GRACE_PERIOD,
-            minimumDelay: 0,
-            maximumDelay: 365 days,
             guardian:     guardian
         });
 

--- a/test/BaseChainCrosschainTest.t.sol
+++ b/test/BaseChainCrosschainTest.t.sol
@@ -44,8 +44,6 @@ contract BaseChainCrosschainTest is CrosschainTestBase {
         bridgeExecutor = new AuthBridgeExecutor(
             defaultL2BridgeExecutorArgs.delay,
             defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.minimumDelay,
-            defaultL2BridgeExecutorArgs.maximumDelay,
             defaultL2BridgeExecutorArgs.guardian
         );
         bridgeReceiver = address(new BridgeExecutorReceiverOptimism(

--- a/test/CrosschainTestBase.sol
+++ b/test/CrosschainTestBase.sol
@@ -20,8 +20,6 @@ struct L2BridgeExecutorArguments {
     address ethereumGovernanceExecutor;
     uint256 delay;
     uint256 gracePeriod;
-    uint256 minimumDelay;
-    uint256 maximumDelay;
     address guardian;
 }
 
@@ -72,8 +70,6 @@ abstract contract CrosschainTestBase is Test {
         ethereumGovernanceExecutor: L1_EXECUTOR,
         delay:                      600,
         gracePeriod:                1200,
-        minimumDelay:               0,
-        maximumDelay:               2400,
         guardian:                   GUARDIAN
     });
 
@@ -317,14 +313,6 @@ abstract contract CrosschainTestBase is Test {
             defaultL2BridgeExecutorArgs.gracePeriod
         );
         assertEq(
-            bridgeExecutor.getMinimumDelay(),
-            defaultL2BridgeExecutorArgs.minimumDelay
-        );
-        assertEq(
-            bridgeExecutor.getMaximumDelay(),
-            defaultL2BridgeExecutorArgs.maximumDelay
-        );
-        assertEq(
             bridgeExecutor.getGuardian(),
             defaultL2BridgeExecutorArgs.guardian
         );
@@ -333,16 +321,12 @@ abstract contract CrosschainTestBase is Test {
             ethereumGovernanceExecutor: defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             delay:                      1200,
             gracePeriod:                1800,
-            minimumDelay:               100,
-            maximumDelay:               3600,
             guardian:                   makeAddr('newGuardian')
         });
 
         IPayload reconfigurationPayload = IPayload(new ReconfigurationPayload(
             newL2BridgeExecutorParams.delay,
             newL2BridgeExecutorParams.gracePeriod,
-            newL2BridgeExecutorParams.minimumDelay,
-            newL2BridgeExecutorParams.maximumDelay,
             newL2BridgeExecutorParams.guardian
         ));
 
@@ -372,14 +356,6 @@ abstract contract CrosschainTestBase is Test {
         assertEq(
             bridgeExecutor.getGracePeriod(),
             newL2BridgeExecutorParams.gracePeriod
-        );
-        assertEq(
-            bridgeExecutor.getMinimumDelay(),
-            newL2BridgeExecutorParams.minimumDelay
-        );
-        assertEq(
-            bridgeExecutor.getMaximumDelay(),
-            newL2BridgeExecutorParams.maximumDelay
         );
         assertEq(
             bridgeExecutor.getGuardian(),

--- a/test/GnosisCrosschainTest.t.sol
+++ b/test/GnosisCrosschainTest.t.sol
@@ -46,8 +46,6 @@ contract GnosisCrosschainTest is CrosschainTestBase {
         bridgeExecutor = new AuthBridgeExecutor(
             defaultL2BridgeExecutorArgs.delay,
             defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.minimumDelay,
-            defaultL2BridgeExecutorArgs.maximumDelay,
             defaultL2BridgeExecutorArgs.guardian
         );
         bridgeReceiver = address(new BridgeExecutorReceiverGnosis(

--- a/test/OptimismCrosschainTest.t.sol
+++ b/test/OptimismCrosschainTest.t.sol
@@ -44,8 +44,6 @@ contract OptimismCrosschainTest is CrosschainTestBase {
         bridgeExecutor = new AuthBridgeExecutor(
             defaultL2BridgeExecutorArgs.delay,
             defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.minimumDelay,
-            defaultL2BridgeExecutorArgs.maximumDelay,
             defaultL2BridgeExecutorArgs.guardian
         );
         bridgeReceiver = address(new BridgeExecutorReceiverOptimism(

--- a/test/mocks/ReconfigurationPayload.sol
+++ b/test/mocks/ReconfigurationPayload.sol
@@ -12,29 +12,21 @@ contract ReconfigurationPayload is IPayload {
 
     uint256 public immutable newDelay;
     uint256 public immutable newGracePeriod;
-    uint256 public immutable newMinimumDelay;
-    uint256 public immutable newMaximumDelay;
     address public immutable newGuardian;
 
     constructor(
         uint256 _newDelay,
         uint256 _newGracePeriod,
-        uint256 _newMinimumDelay,
-        uint256 _newMaximumDelay,
         address _newGuardian
     ) {
         newDelay        = _newDelay;
         newGracePeriod  = _newGracePeriod;
-        newMinimumDelay = _newMinimumDelay;
-        newMaximumDelay = _newMaximumDelay;
         newGuardian     = _newGuardian;
     }
 
     function execute() external override {
         IExecutorBase(address(this)).updateDelay(getNewDelay());
         IExecutorBase(address(this)).updateGracePeriod(getNewGracePeriod());
-        IExecutorBase(address(this)).updateMinimumDelay(getNewMinimumDelay());
-        IExecutorBase(address(this)).updateMaximumDelay(getNewMaximumDelay());
         IExecutorBase(address(this)).updateGuardian(getNewGuardian());
     }
 
@@ -44,14 +36,6 @@ contract ReconfigurationPayload is IPayload {
 
     function getNewGracePeriod() public view returns (uint256) {
         return newGracePeriod;
-    }
-
-    function getNewMinimumDelay() public view returns (uint256) {
-        return newMinimumDelay;
-    }
-
-    function getNewMaximumDelay() public view returns (uint256) {
-        return newMaximumDelay;
     }
 
     function getNewGuardian() public view returns (address) {


### PR DESCRIPTION
Min and max delay provide no additional protection as the min/max can be changed right before updating the actual delay. We can remove it.