### PR TITLE
[SC-428] Remove bridge role

### DIFF
--- a/src/executors/AuthBridgeExecutor.sol
+++ b/src/executors/AuthBridgeExecutor.sol
@@ -11,8 +11,6 @@ import { BridgeExecutorBase }  from './BridgeExecutorBase.sol';
  * @notice Queue up proposals from an authorized bridge.
  */
 contract AuthBridgeExecutor is IAuthBridgeExecutor, AccessControl, BridgeExecutorBase {
-
-    bytes32 public constant AUTHORIZED_BRIDGE_ROLE = keccak256('AUTHORIZED_BRIDGE_ROLE');
     
     /**
      * @dev Constructor
@@ -39,7 +37,6 @@ contract AuthBridgeExecutor is IAuthBridgeExecutor, AccessControl, BridgeExecuto
         )
     {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _setRoleAdmin(AUTHORIZED_BRIDGE_ROLE, DEFAULT_ADMIN_ROLE);
     }
 
     /// @inheritdoc IAuthBridgeExecutor
@@ -49,7 +46,7 @@ contract AuthBridgeExecutor is IAuthBridgeExecutor, AccessControl, BridgeExecuto
         string[] memory signatures,
         bytes[] memory calldatas,
         bool[] memory withDelegatecalls
-    ) external onlyRole(AUTHORIZED_BRIDGE_ROLE) {
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _queue(targets, values, signatures, calldatas, withDelegatecalls);
     }
     

--- a/test/ArbitrumOneCrosschainTest.t.sol
+++ b/test/ArbitrumOneCrosschainTest.t.sol
@@ -54,7 +54,7 @@ contract ArbitrumOneCrosschainTest is CrosschainTestBase {
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             bridgeExecutor
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.AUTHORIZED_BRIDGE_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
 
         hostDomain.selectFork();
         vm.deal(L1_EXECUTOR, 0.01 ether);

--- a/test/AuthBridgeExecutor.t.sol
+++ b/test/AuthBridgeExecutor.t.sol
@@ -72,9 +72,8 @@ contract AuthBridgeExecutorTestBase is Test {
             maximumDelay: 365 days,  // TODO: removing this in next PR
             guardian:     guardian
         });
-        executor.grantRole(executor.AUTHORIZED_BRIDGE_ROLE(), bridge);
-        executor.grantRole(executor.DEFAULT_ADMIN_ROLE(),     bridge);
-        executor.revokeRole(executor.DEFAULT_ADMIN_ROLE(),    address(this));
+        executor.grantRole(executor.DEFAULT_ADMIN_ROLE(),  bridge);
+        executor.revokeRole(executor.DEFAULT_ADMIN_ROLE(), address(this));
     }
 
     /******************************************************************************************************************/
@@ -194,15 +193,14 @@ contract AuthBridgeExecutorConstructorTests is AuthBridgeExecutorTestBase {
         assertEq(executor.getGuardian(),    guardian);
 
         assertEq(executor.hasRole(executor.DEFAULT_ADMIN_ROLE(), address(this)), true);
-        assertEq(executor.getRoleAdmin(executor.AUTHORIZED_BRIDGE_ROLE()),       executor.DEFAULT_ADMIN_ROLE());
     }
 
 }
 
 contract AuthBridgeExecutorQueueTests is AuthBridgeExecutorTestBase {
 
-    function test_queue_onlyBridge() public {
-        vm.expectRevert(abi.encodeWithSignature("AccessControlUnauthorizedAccount(address,bytes32)", address(this), executor.AUTHORIZED_BRIDGE_ROLE()));
+    function test_queue_onlyDefaultAdmin() public {
+        vm.expectRevert(abi.encodeWithSignature("AccessControlUnauthorizedAccount(address,bytes32)", address(this), executor.DEFAULT_ADMIN_ROLE()));
         executor.queue(new address[](0), new uint256[](0), new string[](0), new bytes[](0), new bool[](0));
     }
 

--- a/test/BaseChainCrosschainTest.t.sol
+++ b/test/BaseChainCrosschainTest.t.sol
@@ -52,7 +52,7 @@ contract BaseChainCrosschainTest is CrosschainTestBase {
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             bridgeExecutor
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.AUTHORIZED_BRIDGE_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
 
         hostDomain.selectFork();
     }

--- a/test/GnosisCrosschainTest.t.sol
+++ b/test/GnosisCrosschainTest.t.sol
@@ -56,7 +56,7 @@ contract GnosisCrosschainTest is CrosschainTestBase {
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             bridgeExecutor
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.AUTHORIZED_BRIDGE_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
 
         hostDomain.selectFork();
     }

--- a/test/OptimismCrosschainTest.t.sol
+++ b/test/OptimismCrosschainTest.t.sol
@@ -52,7 +52,7 @@ contract OptimismCrosschainTest is CrosschainTestBase {
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             bridgeExecutor
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.AUTHORIZED_BRIDGE_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
 
         hostDomain.selectFork();
     }


### PR DESCRIPTION
The bridge role is redundant with the admin role because the bridge is admin of itself. Removing the bridge role.