### PR TITLE
[SC-472] Move everything to AccessControl roles

### DIFF
--- a/src/interfaces/IExecutor.sol
+++ b/src/interfaces/IExecutor.sol
@@ -11,13 +11,7 @@ import { IAccessControl } from 'openzeppelin-contracts/contracts/access/IAccessC
 interface IExecutor is IAccessControl {
 
     error InvalidInitParams();
-    error NotGuardian();
-    error OnlyCallableByThis();
-    error MinimumDelayTooLong();
-    error MaximumDelayTooShort();
     error GracePeriodTooShort();
-    error DelayShorterThanMin();
-    error DelayLongerThanMax();
     error OnlyQueuedActions();
     error TimelockNotFinished();
     error InvalidActionsSetId();
@@ -25,7 +19,6 @@ interface IExecutor is IAccessControl {
     error InconsistentParamsLength();
     error DuplicateAction();
     error InsufficientBalance();
-    error FailedActionExecution();
 
     /**
      * @notice This enum contains all possible actions set states
@@ -98,13 +91,6 @@ interface IExecutor is IAccessControl {
     event ActionsSetCanceled(uint256 indexed id);
 
     /**
-     * @dev Emitted when a new guardian is set
-     * @param oldGuardian The address of the old guardian
-     * @param newGuardian The address of the new guardian
-     **/
-    event GuardianUpdate(address oldGuardian, address newGuardian);
-
-    /**
      * @dev Emitted when the delay (between queueing and execution) is updated
      * @param oldDelay The value of the old delay
      * @param newDelay The value of the new delay
@@ -117,6 +103,16 @@ interface IExecutor is IAccessControl {
      * @param newGracePeriod The value of the new grace period
      **/
     event GracePeriodUpdate(uint256 oldGracePeriod, uint256 newGracePeriod);
+
+    /**
+     * @notice The role that allows submission of a queued action.
+     **/
+    function SUBMISSION_ROLE() external view returns (bytes32);
+
+    /**
+     * @notice The role that allows a guardian to cancel a pending action.
+     **/
+    function GUARDIAN_ROLE() external view returns (bytes32);
 
     /**
      * @notice Queue an ActionsSet
@@ -146,12 +142,6 @@ interface IExecutor is IAccessControl {
      * @param actionsSetId The id of the ActionsSet to cancel
      **/
     function cancel(uint256 actionsSetId) external;
-
-    /**
-     * @notice Update guardian
-     * @param guardian The address of the new guardian
-     **/
-    function updateGuardian(address guardian) external;
 
     /**
      * @notice Update the delay, time between queueing and execution of ActionsSet
@@ -194,12 +184,6 @@ interface IExecutor is IAccessControl {
      * @return The value of the grace period (in seconds)
      **/
     function getGracePeriod() external view returns (uint256);
-
-    /**
-     * @notice Returns the address of the guardian
-     * @return The address of the guardian
-     **/
-    function getGuardian() external view returns (address);
 
     /**
      * @notice Returns the total number of actions sets of the executor

--- a/test/ArbitrumOneCrosschainTest.t.sol
+++ b/test/ArbitrumOneCrosschainTest.t.sol
@@ -45,14 +45,15 @@ contract ArbitrumOneCrosschainTest is CrosschainTestBase {
         bridge.destination.selectFork();
         bridgeExecutor = new Executor(
             defaultL2BridgeExecutorArgs.delay,
-            defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.guardian
+            defaultL2BridgeExecutorArgs.gracePeriod
         );
         bridgeReceiver = address(new ArbitrumReceiver(
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             address(bridgeExecutor)
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.SUBMISSION_ROLE(),     bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.GUARDIAN_ROLE(),       defaultL2BridgeExecutorArgs.guardian);
+        bridgeExecutor.revokeRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), address(this));
 
         bridge.source.selectFork();
         vm.deal(L1_EXECUTOR, 0.01 ether);

--- a/test/BaseChainCrosschainTest.t.sol
+++ b/test/BaseChainCrosschainTest.t.sol
@@ -43,14 +43,15 @@ contract BaseChainCrosschainTest is CrosschainTestBase {
         bridge.destination.selectFork();
         bridgeExecutor = new Executor(
             defaultL2BridgeExecutorArgs.delay,
-            defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.guardian
+            defaultL2BridgeExecutorArgs.gracePeriod
         );
         bridgeReceiver = address(new OptimismReceiver(
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             address(bridgeExecutor)
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.SUBMISSION_ROLE(),     bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.GUARDIAN_ROLE(),       defaultL2BridgeExecutorArgs.guardian);
+        bridgeExecutor.revokeRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), address(this));
 
         bridge.source.selectFork();
     }

--- a/test/CrosschainTestBase.sol
+++ b/test/CrosschainTestBase.sol
@@ -306,6 +306,13 @@ abstract contract CrosschainTestBase is Test {
     function test_selfReconfiguration() public {
         bridge.destination.selectFork();
 
+        L2BridgeExecutorArguments memory newL2BridgeExecutorParams = L2BridgeExecutorArguments({
+            ethereumGovernanceExecutor: defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
+            delay:                      1200,
+            gracePeriod:                1800,
+            guardian:                   makeAddr('newGuardian')
+        });
+
         assertEq(
             bridgeExecutor.getDelay(),
             defaultL2BridgeExecutorArgs.delay
@@ -315,20 +322,18 @@ abstract contract CrosschainTestBase is Test {
             defaultL2BridgeExecutorArgs.gracePeriod
         );
         assertEq(
-            bridgeExecutor.getGuardian(),
-            defaultL2BridgeExecutorArgs.guardian
+            bridgeExecutor.hasRole(bridgeExecutor.GUARDIAN_ROLE(), defaultL2BridgeExecutorArgs.guardian),
+            true
         );
-
-        L2BridgeExecutorArguments memory newL2BridgeExecutorParams = L2BridgeExecutorArguments({
-            ethereumGovernanceExecutor: defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
-            delay:                      1200,
-            gracePeriod:                1800,
-            guardian:                   makeAddr('newGuardian')
-        });
+        assertEq(
+            bridgeExecutor.hasRole(bridgeExecutor.GUARDIAN_ROLE(), newL2BridgeExecutorParams.guardian),
+            false
+        );
 
         IPayload reconfigurationPayload = IPayload(new ReconfigurationPayload(
             newL2BridgeExecutorParams.delay,
             newL2BridgeExecutorParams.gracePeriod,
+            defaultL2BridgeExecutorArgs.guardian,
             newL2BridgeExecutorParams.guardian
         ));
 
@@ -360,8 +365,12 @@ abstract contract CrosschainTestBase is Test {
             newL2BridgeExecutorParams.gracePeriod
         );
         assertEq(
-            bridgeExecutor.getGuardian(),
-            newL2BridgeExecutorParams.guardian
+            bridgeExecutor.hasRole(bridgeExecutor.GUARDIAN_ROLE(), defaultL2BridgeExecutorArgs.guardian),
+            false
+        );
+        assertEq(
+            bridgeExecutor.hasRole(bridgeExecutor.GUARDIAN_ROLE(), newL2BridgeExecutorParams.guardian),
+            true
         );
     }
 

--- a/test/Executor.t.sol
+++ b/test/Executor.t.sol
@@ -65,8 +65,8 @@ contract ExecutorTestBase is Test {
 
     function setUp() public {
         executor = new Executor({
-            delay:        DELAY,
-            gracePeriod:  GRACE_PERIOD
+            delay:       DELAY,
+            gracePeriod: GRACE_PERIOD
         });
         executor.grantRole(executor.SUBMISSION_ROLE(),     bridge);
         executor.grantRole(executor.GUARDIAN_ROLE(),       guardian);
@@ -154,13 +154,13 @@ contract ExecutorConstructorTests is ExecutorTestBase {
     function test_constructor_invalidInitParams_boundary() public {
         vm.expectRevert(abi.encodeWithSignature("InvalidInitParams()"));
         executor = new Executor({
-            delay:        DELAY,
-            gracePeriod:  10 minutes - 1
+            delay:       DELAY,
+            gracePeriod: 10 minutes - 1
         });
 
         executor = new Executor({
-            delay:        DELAY,
-            gracePeriod:  10 minutes
+            delay:       DELAY,
+            gracePeriod: 10 minutes
         });
     }
 
@@ -170,8 +170,8 @@ contract ExecutorConstructorTests is ExecutorTestBase {
         vm.expectEmit();
         emit GracePeriodUpdate(0, GRACE_PERIOD);
         executor = new Executor({
-            delay:        DELAY,
-            gracePeriod:  GRACE_PERIOD
+            delay:       DELAY,
+            gracePeriod: GRACE_PERIOD
         });
 
         assertEq(executor.getDelay(),       DELAY);

--- a/test/GnosisCrosschainTest.t.sol
+++ b/test/GnosisCrosschainTest.t.sol
@@ -42,8 +42,7 @@ contract GnosisCrosschainTest is CrosschainTestBase {
         bridge.destination.selectFork();
         bridgeExecutor = new Executor(
             defaultL2BridgeExecutorArgs.delay,
-            defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.guardian
+            defaultL2BridgeExecutorArgs.gracePeriod
         );
         bridgeReceiver = address(new AMBReceiver(
             AMBBridgeTesting.getGnosisMessengerFromChainAlias(bridge.destination.chain.chainAlias),
@@ -51,7 +50,9 @@ contract GnosisCrosschainTest is CrosschainTestBase {
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             address(bridgeExecutor)
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.SUBMISSION_ROLE(),     bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.GUARDIAN_ROLE(),       defaultL2BridgeExecutorArgs.guardian);
+        bridgeExecutor.revokeRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), address(this));
 
         bridge.source.selectFork();
     }

--- a/test/OptimismCrosschainTest.t.sol
+++ b/test/OptimismCrosschainTest.t.sol
@@ -43,14 +43,15 @@ contract OptimismCrosschainTest is CrosschainTestBase {
         bridge.destination.selectFork();
         bridgeExecutor = new Executor(
             defaultL2BridgeExecutorArgs.delay,
-            defaultL2BridgeExecutorArgs.gracePeriod,
-            defaultL2BridgeExecutorArgs.guardian
+            defaultL2BridgeExecutorArgs.gracePeriod
         );
         bridgeReceiver = address(new OptimismReceiver(
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
             address(bridgeExecutor)
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.SUBMISSION_ROLE(),     bridgeReceiver);
+        bridgeExecutor.grantRole(bridgeExecutor.GUARDIAN_ROLE(),       defaultL2BridgeExecutorArgs.guardian);
+        bridgeExecutor.revokeRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), address(this));
 
         bridge.source.selectFork();
     }

--- a/test/mocks/ReconfigurationPayload.sol
+++ b/test/mocks/ReconfigurationPayload.sol
@@ -12,22 +12,26 @@ contract ReconfigurationPayload is IPayload {
 
     uint256 public immutable newDelay;
     uint256 public immutable newGracePeriod;
+    address public immutable oldGuardian;
     address public immutable newGuardian;
 
     constructor(
         uint256 _newDelay,
         uint256 _newGracePeriod,
+        address _oldGuardian,
         address _newGuardian
     ) {
         newDelay        = _newDelay;
         newGracePeriod  = _newGracePeriod;
+        oldGuardian     = _oldGuardian;
         newGuardian     = _newGuardian;
     }
 
     function execute() external override {
         IExecutor(address(this)).updateDelay(getNewDelay());
         IExecutor(address(this)).updateGracePeriod(getNewGracePeriod());
-        IExecutor(address(this)).updateGuardian(getNewGuardian());
+        IExecutor(address(this)).revokeRole(IExecutor(address(this)).GUARDIAN_ROLE(), getOldGuardian());
+        IExecutor(address(this)).grantRole(IExecutor(address(this)).GUARDIAN_ROLE(), getNewGuardian());
     }
 
     function getNewDelay() public view returns (uint256) {
@@ -36,6 +40,10 @@ contract ReconfigurationPayload is IPayload {
 
     function getNewGracePeriod() public view returns (uint256) {
         return newGracePeriod;
+    }
+
+    function getOldGuardian() public view returns (address) {
+        return oldGuardian;
     }
 
     function getNewGuardian() public view returns (address) {


### PR DESCRIPTION
This PR removes the `onlyThis` and `onlyGuardian` modifiers and merges them into the more general access control contract. You may be wondering why the bridge receiver was moved back to a non-default-admin role `SUBMISSION_ROLE `. This is because all that actions that are admin such as set the guardian, update delay, etc should only be accessible behind the delay. IE the receiver (eg. `OptimismReceiver`) should not be overall admin able to execute changes without the delay.

Instead `queue` should be specific to bridge receiver to put a message in a delay, and the default admin is the contract itself. See: `_grantRole(DEFAULT_ADMIN_ROLE, address(this));` in the `Executor` constructor.

So in summary:

Submission role: can submit messages under a delay
Guardian role: can cancel queued messages
Default admin role: can do anything without delay including change delay, guardian role, submission role, etc.