### PR TITLE
[SC-473] Refactor integration tests to make it easier to add many domains

### DIFF
--- a/test/BaseChainCrosschainTest.t.sol
+++ b/test/BaseChainCrosschainTest.t.sol
@@ -7,21 +7,7 @@ import { OptimismBridgeTesting } from 'lib/xchain-helpers/src/testing/bridges/Op
 import { OptimismForwarder }     from 'lib/xchain-helpers/src/forwarders/OptimismForwarder.sol';
 import { OptimismReceiver }      from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
 
-contract BaseChainCrosschainPayload is CrosschainPayload {
-
-    constructor(IPayload _targetPayload, address _bridgeReceiver)
-        CrosschainPayload(_targetPayload, _bridgeReceiver) {}
-
-    function execute() external override {
-        OptimismForwarder.sendMessageL1toL2(
-            OptimismForwarder.L1_CROSS_DOMAIN_BASE,
-            bridgeReceiver,
-            encodeCrosschainExecutionMessage(),
-            1_000_000
-        );
-    }
-
-}
+import { OptimismCrosschainPayload } from './payloads/OptimismCrosschainPayload.sol';
 
 contract BaseChainCrosschainTest is CrosschainTestBase {
 
@@ -29,31 +15,23 @@ contract BaseChainCrosschainTest is CrosschainTestBase {
     using OptimismBridgeTesting for *;
 
     function deployCrosschainPayload(IPayload targetPayload, address bridgeReceiver)
-        public override returns (IPayload)
+        internal override returns (IPayload)
     {
-        return IPayload(new BaseChainCrosschainPayload(targetPayload, bridgeReceiver));
+        return IPayload(new OptimismCrosschainPayload(OptimismForwarder.L1_CROSS_DOMAIN_BASE, targetPayload, bridgeReceiver));
     }
 
-    function setUp() public {
+    function setupDomain() internal override {
+        remote = getChain('base').createFork();
         bridge = OptimismBridgeTesting.createNativeBridge(
-            getChain('mainnet').createFork(),
-            getChain('base').createFork()
+            mainnet,
+            remote
         );
 
-        bridge.destination.selectFork();
-        bridgeExecutor = new Executor(
-            defaultL2BridgeExecutorArgs.delay,
-            defaultL2BridgeExecutorArgs.gracePeriod
-        );
+        remote.selectFork();
         bridgeReceiver = address(new OptimismReceiver(
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
-            address(bridgeExecutor)
+            vm.computeCreateAddress(address(this), 2)
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.SUBMISSION_ROLE(),     bridgeReceiver);
-        bridgeExecutor.grantRole(bridgeExecutor.GUARDIAN_ROLE(),       defaultL2BridgeExecutorArgs.guardian);
-        bridgeExecutor.revokeRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), address(this));
-
-        bridge.source.selectFork();
     }
 
     function relayMessagesAcrossBridge() internal override {

--- a/test/GnosisCrosschainTest.t.sol
+++ b/test/GnosisCrosschainTest.t.sol
@@ -4,23 +4,9 @@ pragma solidity ^0.8.0;
 import './CrosschainTestBase.sol';
 
 import { AMBBridgeTesting } from 'lib/xchain-helpers/src/testing/bridges/AMBBridgeTesting.sol';
-import { AMBForwarder }     from 'lib/xchain-helpers/src/forwarders/AMBForwarder.sol';
 import { AMBReceiver }      from 'lib/xchain-helpers/src/receivers/AMBReceiver.sol';
 
-contract GnosisCrosschainPayload is CrosschainPayload {
-
-    constructor(IPayload _targetPayload, address _bridgeReceiver)
-        CrosschainPayload(_targetPayload, _bridgeReceiver) {}
-
-    function execute() external override {
-        AMBForwarder.sendMessageEthereumToGnosisChain(
-            bridgeReceiver,
-            encodeCrosschainExecutionMessage(),
-            1_000_000
-        );
-    }
-
-}
+import { GnosisCrosschainPayload } from './payloads/GnosisCrosschainPayload.sol';
 
 contract GnosisCrosschainTest is CrosschainTestBase {
 
@@ -28,33 +14,25 @@ contract GnosisCrosschainTest is CrosschainTestBase {
     using AMBBridgeTesting for *;
 
     function deployCrosschainPayload(IPayload targetPayload, address bridgeReceiver)
-        public override returns (IPayload)
+        internal override returns (IPayload)
     {
         return IPayload(new GnosisCrosschainPayload(targetPayload, bridgeReceiver));
     }
 
-    function setUp() public {
+    function setupDomain() internal override {
+        remote = getChain('gnosis_chain').createFork();
         bridge = AMBBridgeTesting.createGnosisBridge(
-            getChain('mainnet').createFork(),
-            getChain('gnosis_chain').createFork()
+            mainnet,
+            remote
         );
 
-        bridge.destination.selectFork();
-        bridgeExecutor = new Executor(
-            defaultL2BridgeExecutorArgs.delay,
-            defaultL2BridgeExecutorArgs.gracePeriod
-        );
+        remote.selectFork();
         bridgeReceiver = address(new AMBReceiver(
             AMBBridgeTesting.getGnosisMessengerFromChainAlias(bridge.destination.chain.chainAlias),
             bytes32(uint256(1)),  // Ethereum chainid
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
-            address(bridgeExecutor)
+            vm.computeCreateAddress(address(this), 2)
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.SUBMISSION_ROLE(),     bridgeReceiver);
-        bridgeExecutor.grantRole(bridgeExecutor.GUARDIAN_ROLE(),       defaultL2BridgeExecutorArgs.guardian);
-        bridgeExecutor.revokeRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), address(this));
-
-        bridge.source.selectFork();
     }
 
     function relayMessagesAcrossBridge() internal override {

--- a/test/OptimismCrosschainTest.t.sol
+++ b/test/OptimismCrosschainTest.t.sol
@@ -7,53 +7,31 @@ import { OptimismBridgeTesting } from 'lib/xchain-helpers/src/testing/bridges/Op
 import { OptimismForwarder }     from 'lib/xchain-helpers/src/forwarders/OptimismForwarder.sol';
 import { OptimismReceiver }      from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
 
-contract OptimismCrosschainPayload is CrosschainPayload {
+import { OptimismCrosschainPayload } from './payloads/OptimismCrosschainPayload.sol';
 
-    constructor(IPayload _targetPayload, address _bridgeReceiver)
-        CrosschainPayload(_targetPayload, _bridgeReceiver) {}
-
-    function execute() external override {
-        OptimismForwarder.sendMessageL1toL2(
-            OptimismForwarder.L1_CROSS_DOMAIN_OPTIMISM,
-            bridgeReceiver,
-            encodeCrosschainExecutionMessage(),
-            1_000_000
-        );
-    }
-
-}
-
-contract OptimismCrosschainTest is CrosschainTestBase {
+contract BaseChainCrosschainTest is CrosschainTestBase {
 
     using DomainHelpers         for *;
     using OptimismBridgeTesting for *;
 
     function deployCrosschainPayload(IPayload targetPayload, address bridgeReceiver)
-        public override returns (IPayload)
+        internal override returns (IPayload)
     {
-        return IPayload(new OptimismCrosschainPayload(targetPayload, bridgeReceiver));
+        return IPayload(new OptimismCrosschainPayload(OptimismForwarder.L1_CROSS_DOMAIN_OPTIMISM, targetPayload, bridgeReceiver));
     }
 
-    function setUp() public {
+    function setupDomain() internal override {
+        remote = getChain('optimism').createFork();
         bridge = OptimismBridgeTesting.createNativeBridge(
-            getChain('mainnet').createFork(),
-            getChain('optimism').createFork()
+            mainnet,
+            remote
         );
 
-        bridge.destination.selectFork();
-        bridgeExecutor = new Executor(
-            defaultL2BridgeExecutorArgs.delay,
-            defaultL2BridgeExecutorArgs.gracePeriod
-        );
+        remote.selectFork();
         bridgeReceiver = address(new OptimismReceiver(
             defaultL2BridgeExecutorArgs.ethereumGovernanceExecutor,
-            address(bridgeExecutor)
+            vm.computeCreateAddress(address(this), 2)
         ));
-        bridgeExecutor.grantRole(bridgeExecutor.SUBMISSION_ROLE(),     bridgeReceiver);
-        bridgeExecutor.grantRole(bridgeExecutor.GUARDIAN_ROLE(),       defaultL2BridgeExecutorArgs.guardian);
-        bridgeExecutor.revokeRole(bridgeExecutor.DEFAULT_ADMIN_ROLE(), address(this));
-
-        bridge.source.selectFork();
     }
 
     function relayMessagesAcrossBridge() internal override {

--- a/test/interfaces/IL1Executor.sol
+++ b/test/interfaces/IL1Executor.sol
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.0;
-
-interface IL1Executor {
-    function exec(address target, bytes calldata args)
-        external
-        payable
-        returns (bytes memory out);
-}

--- a/test/mocks/PayloadWithEmit.sol
+++ b/test/mocks/PayloadWithEmit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.10;
 
-import { IPayload } from '../interfaces/IPayload.sol';
+import { IPayload } from '../payloads/IPayload.sol';
 
 /**
  * @dev This payload simply emits an event on execution

--- a/test/mocks/ReconfigurationPayload.sol
+++ b/test/mocks/ReconfigurationPayload.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import { IExecutor } from 'src/interfaces/IExecutor.sol';
 
-import { IPayload } from '../interfaces/IPayload.sol';
+import { IPayload } from '../payloads/IPayload.sol';
 
 /**
  * @dev This payload reconfigures bridge executor to a given state

--- a/test/payloads/ArbitrumCrosschainPayload.sol
+++ b/test/payloads/ArbitrumCrosschainPayload.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import { ArbitrumForwarder } from 'lib/xchain-helpers/src/forwarders/ArbitrumForwarder.sol';
+
+import { CrosschainPayload, IPayload } from './CrosschainPayload.sol';
+
+contract ArbitrumCrosschainPayload is CrosschainPayload {
+
+    address public immutable l1CrossDomain;
+
+    constructor(address _l1CrossDomain, IPayload _targetPayload, address _bridgeReceiver) CrosschainPayload(_targetPayload, _bridgeReceiver) {
+        l1CrossDomain = _l1CrossDomain;
+    }
+
+    function execute() external override {
+        ArbitrumForwarder.sendMessageL1toL2(
+            l1CrossDomain,
+            bridgeReceiver,
+            encodeCrosschainExecutionMessage(),
+            1_000_000,
+            1 gwei,
+            block.basefee + 10 gwei
+        );
+    }
+
+}

--- a/test/payloads/CrosschainPayload.sol
+++ b/test/payloads/CrosschainPayload.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import { IExecutor } from 'src/interfaces/IExecutor.sol';
+
+import { IPayload } from './IPayload.sol';
+
+abstract contract CrosschainPayload is IPayload {
+
+    IPayload immutable targetPayload;
+    address  immutable bridgeReceiver;
+
+    constructor(IPayload _targetPayload, address _bridgeReceiver) {
+        targetPayload  = _targetPayload;
+        bridgeReceiver = _bridgeReceiver;
+    }
+
+    function execute() external virtual;
+
+    function encodeCrosschainExecutionMessage() internal view returns (bytes memory) {
+        address[] memory targets = new address[](1);
+        targets[0] = address(targetPayload);
+        uint256[] memory values = new uint256[](1);
+        values[0] = 0;
+        string[] memory signatures = new string[](1);
+        signatures[0] = 'execute()';
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = '';
+        bool[] memory withDelegatecalls = new bool[](1);
+        withDelegatecalls[0] = true;
+
+        return abi.encodeWithSelector(
+            IExecutor.queue.selector,
+            targets,
+            values,
+            signatures,
+            calldatas,
+            withDelegatecalls
+        );
+    }
+
+}

--- a/test/payloads/GnosisCrosschainPayload.sol
+++ b/test/payloads/GnosisCrosschainPayload.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import { AMBForwarder } from 'lib/xchain-helpers/src/forwarders/AMBForwarder.sol';
+
+import { CrosschainPayload, IPayload } from './CrosschainPayload.sol';
+
+contract GnosisCrosschainPayload is CrosschainPayload {
+
+    constructor(IPayload _targetPayload, address _bridgeReceiver) CrosschainPayload(_targetPayload, _bridgeReceiver) {
+    }
+
+    function execute() external override {
+        AMBForwarder.sendMessageEthereumToGnosisChain(
+            bridgeReceiver,
+            encodeCrosschainExecutionMessage(),
+            1_000_000
+        );
+    }
+
+}

--- a/test/payloads/IPayload.sol
+++ b/test/payloads/IPayload.sol
@@ -2,7 +2,5 @@
 pragma solidity ^0.8.10;
 
 interface IPayload {
-
     function execute() external;
-
 }

--- a/test/payloads/OptimismCrosschainPayload.sol
+++ b/test/payloads/OptimismCrosschainPayload.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import { OptimismForwarder } from 'lib/xchain-helpers/src/forwarders/OptimismForwarder.sol';
+
+import { CrosschainPayload, IPayload } from './CrosschainPayload.sol';
+
+contract OptimismCrosschainPayload is CrosschainPayload {
+
+    address public immutable l1CrossDomain;
+
+    constructor(address _l1CrossDomain, IPayload _targetPayload, address _bridgeReceiver) CrosschainPayload(_targetPayload, _bridgeReceiver) {
+        l1CrossDomain = _l1CrossDomain;
+    }
+
+    function execute() external override {
+        OptimismForwarder.sendMessageL1toL2(
+            l1CrossDomain,
+            bridgeReceiver,
+            encodeCrosschainExecutionMessage(),
+            1_000_000
+        );
+    }
+
+}


### PR DESCRIPTION
Basically moving all repetitive logic into the base contract to reduce the amount of changes needed for every domain we add. Also reuse payloads based on domain type. IE base and optimism share payloads of type "Optimism". This will help when we add more OP stack domains.