### PR TITLE
Remove the useless isActionQueued logic

### DIFF
--- a/src/interfaces/IExecutor.sol
+++ b/src/interfaces/IExecutor.sol
@@ -21,7 +21,6 @@ interface IExecutor is IAccessControl {
     error InvalidActionsSetId();
     error EmptyTargets();
     error InconsistentParamsLength();
-    error DuplicateAction();
     error InsufficientBalance();
 
     /******************************************************************************************************************/
@@ -152,14 +151,6 @@ interface IExecutor is IAccessControl {
      * @return The value of the grace period (in seconds)
      **/
     function gracePeriod() external view returns (uint256);
-
-    /**
-     * @notice Returns whether an actions set (by actionHash) is queued.
-     * @dev    actionHash = keccak256(abi.encode(target, value, signature, data, executionTime, withDelegatecall)).
-     * @param  actionHash hash of the action to be checked.
-     * @return True if the underlying action of actionHash is queued, false otherwise.
-     **/
-    function isActionQueued(bytes32 actionHash) external view returns (bool);
 
     /******************************************************************************************************************/
     /*** ActionSet functions                                                                                        ***/


### PR DESCRIPTION
From audit review. The logic to prevent duplicate actions is pointless unless it is queued up in the same batch. Bridges already provide guarantees that a single relayed message will only be executed at most once or it would be a very broken bridge.