### PR TITLE
LZ Governance Bridge Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/xchain-helpers"]
 	path = lib/xchain-helpers
-	url = https://github.com/marsfoundation/xchain-helpers
+	url = https://github.com/oldchili/xchain-helpers.git
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/deploy/Deploy.sol
+++ b/deploy/Deploy.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.0;
 
 import { ArbitrumReceiver }    from 'lib/xchain-helpers/src/receivers/ArbitrumReceiver.sol';
-import { LZGovBridgeReceiver } from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
 import { LZReceiver }          from 'lib/xchain-helpers/src/receivers/LZReceiver.sol';
+import { LZGovBridgeReceiver } from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
 import { OptimismReceiver }    from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
 
 import { Executor } from 'src/Executor.sol';
@@ -56,12 +56,12 @@ library Deploy {
     )
         internal returns (address receiver)
     {
-        receiver = address(new LZGovBridgeReceiver(
-            govOappReceiver,
-            srcEid,
-            srcAuthority,
-            executor
-        ));
+        receiver = address(new LZGovBridgeReceiver({
+            _govOappReceiver : govOappReceiver,
+            _srcEid          : srcEid,
+            _srcAuthority    : srcAuthority,
+            _target          : executor
+        }));
     }
 
     function setUpExecutorPermissions(address executor_, address receiver, address deployer)

--- a/deploy/Deploy.sol
+++ b/deploy/Deploy.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.0;
 
-import { ArbitrumReceiver } from 'lib/xchain-helpers/src/receivers/ArbitrumReceiver.sol';
-import { LZReceiver }       from 'lib/xchain-helpers/src/receivers/LZReceiver.sol';
-import { OptimismReceiver } from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
+import { ArbitrumReceiver }    from 'lib/xchain-helpers/src/receivers/ArbitrumReceiver.sol';
+import { LZGovBridgeReceiver } from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
+import { LZReceiver }          from 'lib/xchain-helpers/src/receivers/LZReceiver.sol';
+import { OptimismReceiver }    from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
 
 import { Executor } from 'src/Executor.sol';
 
@@ -45,6 +46,22 @@ library Deploy {
             _delegate            : delegate,
             _owner               : owner
         }));
+    }
+
+    function deployLZGovBridgeReceiver(
+        address govOappReceiver,
+        uint32  srcEid,
+        address srcAuthority,
+        address executor
+    )
+        internal returns (address receiver)
+    {
+        receiver = address(new LZGovBridgeReceiver(
+            govOappReceiver,
+            srcEid,
+            srcAuthority,
+            executor
+        ));
     }
 
     function setUpExecutorPermissions(address executor_, address receiver, address deployer)

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -92,33 +92,6 @@ contract DeployUnichainExecutor is Script {
 
 }
 
-contract DeployLZGovBridgeBaseExecutor is Script {
-
-    function run() public {
-        vm.createSelectFork(getChain("base").rpcUrl);
-
-        address govOappReceiver = vm.envAddress("GOV_OAPP_RECEIVER");
-
-        vm.startBroadcast();
-
-        address executor = Deploy.deployExecutor(0, 7 days);
-        address receiver = Deploy.deployLZGovBridgeReceiver({
-            govOappReceiver : govOappReceiver,
-            srcEid          : LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
-            srcAuthority    : Ethereum.SPARK_PROXY,
-            executor        : executor
-        });
-
-        console.log("executor deployed at:", executor);
-        console.log("receiver deployed at:", receiver);
-
-        Deploy.setUpExecutorPermissions(executor, receiver, msg.sender);
-
-        vm.stopBroadcast();
-    }
-
-}
-
 contract DeployAvalancheExecutor is Script {
 
     function run() public {
@@ -134,6 +107,32 @@ contract DeployAvalancheExecutor is Script {
             executor            : executor,
             delegate            : address(1),
             owner               : address(1)
+        });
+
+        console.log("executor deployed at:", executor);
+        console.log("receiver deployed at:", receiver);
+
+        Deploy.setUpExecutorPermissions(executor, receiver, msg.sender);
+
+        vm.stopBroadcast();
+    }
+
+}
+
+contract DeployLZGovBridgeExecutor is Script {
+
+    function run() public {
+        vm.createSelectFork(vm.envString("DESTINATION_RPC_URL"));
+        address govOappReceiver = vm.envAddress("GOV_OAPP_RECEIVER");
+
+        vm.startBroadcast();
+
+        address executor = Deploy.deployExecutor(0, 7 days);
+        address receiver = Deploy.deployLZGovBridgeReceiver({
+            govOappReceiver : govOappReceiver,
+            srcEid          : LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
+            srcAuthority    : Ethereum.SPARK_PROXY,
+            executor        : executor
         });
 
         console.log("executor deployed at:", executor);

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -138,6 +138,8 @@ contract DeployLZGovBridgeExecutor is Script {
         console.log("executor deployed at:", executor);
         console.log("receiver deployed at:", receiver);
 
+        // Note: this does not grant a GUARDIAN_ROLE on the executor to anyone (same behaviour as the other scripts).
+        // That role should be set modifying the script or through a message.
         Deploy.setUpExecutorPermissions(executor, receiver, msg.sender);
 
         vm.stopBroadcast();

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -5,7 +5,8 @@ import { console } from "forge-std/console.sol";
 
 import { Ethereum } from "lib/spark-address-registry/src/Ethereum.sol";
 
-import { LZForwarder } from "lib/xchain-helpers/src/forwarders/LZForwarder.sol";
+import { LZForwarder }            from "lib/xchain-helpers/src/forwarders/LZForwarder.sol";
+import { LZGovBridgeForwarder }   from "lib/xchain-helpers/src/forwarders/LZGovBridgeForwarder.sol";
 
 import { Script } from 'forge-std/Script.sol';
 
@@ -80,6 +81,33 @@ contract DeployUnichainExecutor is Script {
 
         address executor = Deploy.deployExecutor(0, 7 days);
         address receiver = Deploy.deployOptimismReceiver(Ethereum.SPARK_PROXY, executor);
+
+        console.log("executor deployed at:", executor);
+        console.log("receiver deployed at:", receiver);
+
+        Deploy.setUpExecutorPermissions(executor, receiver, msg.sender);
+
+        vm.stopBroadcast();
+    }
+
+}
+
+contract DeployLZGovBridgeBaseExecutor is Script {
+
+    function run() public {
+        vm.createSelectFork(getChain("base").rpcUrl);
+
+        address govOappReceiver = vm.envAddress("GOV_OAPP_RECEIVER");
+
+        vm.startBroadcast();
+
+        address executor = Deploy.deployExecutor(0, 7 days);
+        address receiver = Deploy.deployLZGovBridgeReceiver({
+            govOappReceiver : govOappReceiver,
+            srcEid          : LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
+            srcAuthority    : Ethereum.SPARK_PROXY,
+            executor        : executor
+        });
 
         console.log("executor deployed at:", executor);
         console.log("receiver deployed at:", receiver);

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.0;
 
 import 'forge-std/Test.sol';
 
-import { OptimismReceiver } from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
+import { LZGovBridgeReceiver } from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
+import { OptimismReceiver }    from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
 
 import { Deploy } from "../deploy/Deploy.sol";
 
@@ -25,6 +26,22 @@ contract DeployTests is Test {
 
         assertEq(OptimismReceiver(receiver).l1Authority(), makeAddr("l1Authority"));
         assertEq(OptimismReceiver(receiver).target(),      makeAddr("executor"));
+    }
+
+    function test_deployLZGovBridgeReceiver() public {
+        LZGovBridgeReceiver receiver = LZGovBridgeReceiver(payable(
+            Deploy.deployLZGovBridgeReceiver(
+                makeAddr("govOappReceiver"),
+                30101,
+                makeAddr("srcAuthority"),
+                makeAddr("executor")
+            )
+        ));
+
+        assertEq(receiver.govOappReceiver(), makeAddr("govOappReceiver"));
+        assertEq(receiver.srcEid(),          30101);
+        assertEq(receiver.srcAuthority(),    makeAddr("srcAuthority"));
+        assertEq(receiver.target(),          makeAddr("executor"));
     }
 
     function test_setUpExecutorPermissions() public {

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.0;
 
 import 'forge-std/Test.sol';
 
-import { LZGovBridgeReceiver } from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
 import { OptimismReceiver }    from 'lib/xchain-helpers/src/receivers/OptimismReceiver.sol';
+import { LZGovBridgeReceiver } from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
 
 import { Deploy } from "../deploy/Deploy.sol";
 

--- a/test/LZGovBridgeCrosschainTest.t.sol
+++ b/test/LZGovBridgeCrosschainTest.t.sol
@@ -26,6 +26,9 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
     using DomainHelpers   for *;
     using LZBridgeTesting for *;
 
+    uint32  constant ENDPOINT_ID_BASE = 30184;
+    address constant ENDPOINT_BASE    = 0x1a44076050125825900e736c501f859c50fE728c;
+
     IChainLog constant chainlog = IChainLog(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
     address govOappSender;
@@ -36,7 +39,7 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
         internal override returns (IPayload)
     {
         return IPayload(new LZGovBridgeCrosschainPayload(
-            LZGovBridgeForwarder.ENDPOINT_ID_BASE,
+            ENDPOINT_ID_BASE,
             govOappSender,
             _bridgeReceiver,
             targetPayload,
@@ -59,12 +62,12 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
         address govOwner = IGovOappSender(govOappSender).owner();
         vm.startPrank(govOwner);
         IGovOappSender(govOappSender).setPeer(
-            LZGovBridgeForwarder.ENDPOINT_ID_BASE,
+            ENDPOINT_ID_BASE,
             bytes32(uint256(uint160(expectedGovOappReceiver)))
         );
         IGovOappSender(govOappSender).setCanCallTarget(
             L1_SPARK_PROXY,
-            LZGovBridgeForwarder.ENDPOINT_ID_BASE,
+            ENDPOINT_ID_BASE,
             bytes32(uint256(uint160(expectedGovBridgeReceiver))),
             true
         );
@@ -78,7 +81,7 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
         govOappReceiver = new GovernanceOAppReceiverMock(
             LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
             bytes32(uint256(uint160(govOappSender))),
-            LZGovBridgeForwarder.ENDPOINT_BASE,
+            ENDPOINT_BASE,
             address(this)
         );
         assertEq(address(govOappReceiver), expectedGovOappReceiver);

--- a/test/LZGovBridgeCrosschainTest.t.sol
+++ b/test/LZGovBridgeCrosschainTest.t.sol
@@ -54,28 +54,6 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
         remote = getChain('base').createFork();
         bridge = LZBridgeTesting.createLZBridge(mainnet, remote);
 
-        uint256 nonce = vm.getNonce(address(this));
-        address expectedGovOappReceiver   = vm.computeCreateAddress(address(this), nonce);
-        address expectedGovBridgeReceiver = vm.computeCreateAddress(address(this), nonce + 1);
-
-        // Configure GovernanceOAppSender on mainnet
-        address govOwner = IGovOappSender(govOappSender).owner();
-        vm.startPrank(govOwner);
-        IGovOappSender(govOappSender).setPeer(
-            ENDPOINT_ID_BASE,
-            bytes32(uint256(uint160(expectedGovOappReceiver)))
-        );
-        IGovOappSender(govOappSender).setCanCallTarget(
-            L1_SPARK_PROXY,
-            ENDPOINT_ID_BASE,
-            bytes32(uint256(uint160(expectedGovBridgeReceiver))),
-            true
-        );
-        vm.stopPrank();
-
-        vm.deal(L1_SPARK_PROXY, 0.01 ether);
-
-        // Deploy destination contracts
         remote.selectFork();
 
         govOappReceiver = new GovernanceOAppReceiverMock(
@@ -84,16 +62,33 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
             ENDPOINT_BASE,
             address(this)
         );
-        assertEq(address(govOappReceiver), expectedGovOappReceiver);
 
-        // bridgeExecutor will be deployed at nonce+2 by super.setUp()
+        // bridgeExecutor will be the next contract deployed on this fork (by CrosschainTestBase.setUp())
+        address expectedExecutor = vm.computeCreateAddress(address(this), vm.getNonce(address(this)) + 1);
         bridgeReceiver = Deploy.deployLZGovBridgeReceiver({
             govOappReceiver : address(govOappReceiver),
             srcEid          : LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
             srcAuthority    : L1_SPARK_PROXY,
-            executor        : vm.computeCreateAddress(address(this), nonce + 2)
+            executor        : expectedExecutor
         });
-        assertEq(bridgeReceiver, expectedGovBridgeReceiver);
+
+        // Configure GovernanceOAppSender on mainnet
+        mainnet.selectFork();
+        address govOwner = IGovOappSender(govOappSender).owner();
+        vm.startPrank(govOwner);
+        IGovOappSender(govOappSender).setPeer(
+            ENDPOINT_ID_BASE,
+            bytes32(uint256(uint160(address(govOappReceiver))))
+        );
+        IGovOappSender(govOappSender).setCanCallTarget(
+            L1_SPARK_PROXY,
+            ENDPOINT_ID_BASE,
+            bytes32(uint256(uint160(bridgeReceiver))),
+            true
+        );
+        vm.stopPrank();
+
+        vm.deal(L1_SPARK_PROXY, 0.01 ether);
     }
 
     function relayMessagesAcrossBridge() internal override {

--- a/test/LZGovBridgeCrosschainTest.t.sol
+++ b/test/LZGovBridgeCrosschainTest.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import './CrosschainTestBase.sol';
+
+import { LZBridgeTesting }                      from 'lib/xchain-helpers/src/testing/bridges/LZBridgeTesting.sol';
+import { LZGovBridgeForwarder }                  from 'lib/xchain-helpers/src/forwarders/LZGovBridgeForwarder.sol';
+import { LZGovBridgeReceiver }                   from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
+
+import { GovernanceOAppReceiverMock } from 'lib/xchain-helpers/test/mocks/lz/GovernanceOAppReceiverMock.sol';
+
+import { LZGovBridgeCrosschainPayload } from './payloads/LZGovBridgeCrosschainPayload.sol';
+
+interface IChainLog {
+    function getAddress(bytes32) external view returns (address);
+}
+
+interface IGovOappSender {
+    function owner() external view returns (address);
+    function setPeer(uint32 _eid, bytes32 _peer) external;
+    function setCanCallTarget(address _srcSender, uint32 _dstEid, bytes32 _dstTarget, bool _canCall) external;
+}
+
+contract LZGovBridgeCrosschainTest is CrosschainTestBase {
+
+    using DomainHelpers   for *;
+    using LZBridgeTesting for *;
+
+    IChainLog constant chainlog = IChainLog(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+
+    address govOappSender;
+
+    GovernanceOAppReceiverMock govOappReceiver;
+
+    function deployCrosschainPayload(IPayload targetPayload, address _bridgeReceiver)
+        internal override returns (IPayload)
+    {
+        return IPayload(new LZGovBridgeCrosschainPayload(
+            LZGovBridgeForwarder.ENDPOINT_ID_BASE,
+            govOappSender,
+            _bridgeReceiver,
+            targetPayload,
+            _bridgeReceiver
+        ));
+    }
+
+    function setupDomain() internal override {
+        mainnet.selectFork();
+        govOappSender = chainlog.getAddress("LZ_GOV_SENDER");
+
+        remote = getChain('base').createFork();
+        bridge = LZBridgeTesting.createLZBridge(mainnet, remote);
+
+        uint256 nonce = vm.getNonce(address(this));
+        address expectedGovOappReceiver   = vm.computeCreateAddress(address(this), nonce);
+        address expectedGovBridgeReceiver = vm.computeCreateAddress(address(this), nonce + 1);
+
+        // Configure GovernanceOAppSender on mainnet
+        address govOwner = IGovOappSender(govOappSender).owner();
+        vm.startPrank(govOwner);
+        IGovOappSender(govOappSender).setPeer(
+            LZGovBridgeForwarder.ENDPOINT_ID_BASE,
+            bytes32(uint256(uint160(expectedGovOappReceiver)))
+        );
+        IGovOappSender(govOappSender).setCanCallTarget(
+            L1_SPARK_PROXY,
+            LZGovBridgeForwarder.ENDPOINT_ID_BASE,
+            bytes32(uint256(uint160(expectedGovBridgeReceiver))),
+            true
+        );
+        vm.stopPrank();
+
+        vm.deal(L1_SPARK_PROXY, 0.01 ether);
+
+        // Deploy destination contracts
+        remote.selectFork();
+
+        govOappReceiver = new GovernanceOAppReceiverMock(
+            LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
+            bytes32(uint256(uint160(govOappSender))),
+            LZGovBridgeForwarder.ENDPOINT_BASE,
+            address(this)
+        );
+        assertEq(address(govOappReceiver), expectedGovOappReceiver);
+
+        // bridgeExecutor will be deployed at nonce+2 by super.setUp()
+        bridgeReceiver = address(new LZGovBridgeReceiver(
+            address(govOappReceiver),
+            LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
+            L1_SPARK_PROXY,
+            vm.computeCreateAddress(address(this), nonce + 2)
+        ));
+        assertEq(bridgeReceiver, expectedGovBridgeReceiver);
+    }
+
+    function relayMessagesAcrossBridge() internal override {
+        bridge.relayMessagesToDestination(true, govOappSender, address(govOappReceiver));
+    }
+
+}

--- a/test/LZGovBridgeCrosschainTest.t.sol
+++ b/test/LZGovBridgeCrosschainTest.t.sol
@@ -3,14 +3,12 @@ pragma solidity ^0.8.0;
 
 import './CrosschainTestBase.sol';
 
-import { LZBridgeTesting }                      from 'lib/xchain-helpers/src/testing/bridges/LZBridgeTesting.sol';
-import { LZGovBridgeForwarder }                  from 'lib/xchain-helpers/src/forwarders/LZGovBridgeForwarder.sol';
-
-import { Deploy } from '../deploy/Deploy.sol';
-
+import { LZBridgeTesting }            from 'lib/xchain-helpers/src/testing/bridges/LZBridgeTesting.sol';
+import { LZGovBridgeForwarder }       from 'lib/xchain-helpers/src/forwarders/LZGovBridgeForwarder.sol';
 import { GovernanceOAppReceiverMock } from 'lib/xchain-helpers/test/mocks/lz/GovernanceOAppReceiverMock.sol';
 
 import { LZGovBridgeCrosschainPayload } from './payloads/LZGovBridgeCrosschainPayload.sol';
+import { Deploy }                       from '../deploy/Deploy.sol';
 
 interface IChainLog {
     function getAddress(bytes32) external view returns (address);

--- a/test/LZGovBridgeCrosschainTest.t.sol
+++ b/test/LZGovBridgeCrosschainTest.t.sol
@@ -5,7 +5,8 @@ import './CrosschainTestBase.sol';
 
 import { LZBridgeTesting }                      from 'lib/xchain-helpers/src/testing/bridges/LZBridgeTesting.sol';
 import { LZGovBridgeForwarder }                  from 'lib/xchain-helpers/src/forwarders/LZGovBridgeForwarder.sol';
-import { LZGovBridgeReceiver }                   from 'lib/xchain-helpers/src/receivers/LZGovBridgeReceiver.sol';
+
+import { Deploy } from '../deploy/Deploy.sol';
 
 import { GovernanceOAppReceiverMock } from 'lib/xchain-helpers/test/mocks/lz/GovernanceOAppReceiverMock.sol';
 
@@ -87,12 +88,12 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
         assertEq(address(govOappReceiver), expectedGovOappReceiver);
 
         // bridgeExecutor will be deployed at nonce+2 by super.setUp()
-        bridgeReceiver = address(new LZGovBridgeReceiver(
-            address(govOappReceiver),
-            LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
-            L1_SPARK_PROXY,
-            vm.computeCreateAddress(address(this), nonce + 2)
-        ));
+        bridgeReceiver = Deploy.deployLZGovBridgeReceiver({
+            govOappReceiver : address(govOappReceiver),
+            srcEid          : LZGovBridgeForwarder.ENDPOINT_ID_ETHEREUM,
+            srcAuthority    : L1_SPARK_PROXY,
+            executor        : vm.computeCreateAddress(address(this), nonce + 2)
+        });
         assertEq(bridgeReceiver, expectedGovBridgeReceiver);
     }
 

--- a/test/LZGovBridgeCrosschainTest.t.sol
+++ b/test/LZGovBridgeCrosschainTest.t.sol
@@ -43,8 +43,7 @@ contract LZGovBridgeCrosschainTest is CrosschainTestBase {
             ENDPOINT_ID_BASE,
             govOappSender,
             _bridgeReceiver,
-            targetPayload,
-            _bridgeReceiver
+            targetPayload
         ));
     }
 

--- a/test/payloads/LZGovBridgeCrosschainPayload.sol
+++ b/test/payloads/LZGovBridgeCrosschainPayload.sol
@@ -19,9 +19,8 @@ contract LZGovBridgeCrosschainPayload is CrosschainPayload {
         uint32   _dstEid,
         address  _govOapp,
         address  _receiver,
-        IPayload _targetPayload,
-        address  _bridgeReceiver
-    ) CrosschainPayload(_targetPayload, _bridgeReceiver) {
+        IPayload _targetPayload
+    ) CrosschainPayload(_targetPayload, address(0)) {
         dstEid  = _dstEid;
         govOapp = _govOapp;
         receiver = _receiver;

--- a/test/payloads/LZGovBridgeCrosschainPayload.sol
+++ b/test/payloads/LZGovBridgeCrosschainPayload.sol
@@ -11,10 +11,9 @@ contract LZGovBridgeCrosschainPayload is CrosschainPayload {
 
     using OptionsBuilder for bytes;
 
+    uint32  public immutable dstEid;
     address public immutable govOapp;
     address public immutable receiver;
-
-    uint32 public immutable dstEid;
 
     constructor(
         uint32   _dstEid,

--- a/test/payloads/LZGovBridgeCrosschainPayload.sol
+++ b/test/payloads/LZGovBridgeCrosschainPayload.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import { OptionsBuilder } from "layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+
+import { LZGovBridgeForwarder, MessagingFee } from 'lib/xchain-helpers/src/forwarders/LZGovBridgeForwarder.sol';
+
+import { CrosschainPayload, IPayload } from './CrosschainPayload.sol';
+
+contract LZGovBridgeCrosschainPayload is CrosschainPayload {
+
+    using OptionsBuilder for bytes;
+
+    address public immutable govOapp;
+    address public immutable receiver;
+
+    uint32 public immutable dstEid;
+
+    constructor(
+        uint32   _dstEid,
+        address  _govOapp,
+        address  _receiver,
+        IPayload _targetPayload,
+        address  _bridgeReceiver
+    ) CrosschainPayload(_targetPayload, _bridgeReceiver) {
+        dstEid  = _dstEid;
+        govOapp = _govOapp;
+        receiver = _receiver;
+    }
+
+    function execute() external override {
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+
+        bytes memory message = encodeCrosschainExecutionMessage();
+
+        MessagingFee memory fee = LZGovBridgeForwarder.quote(
+            govOapp,
+            dstEid,
+            receiver,
+            message,
+            options,
+            false
+        );
+
+        LZGovBridgeForwarder.sendMessage(
+            govOapp,
+            dstEid,
+            receiver,
+            message,
+            options,
+            msg.sender,
+            fee,
+            address(0)
+        );
+    }
+
+}


### PR DESCRIPTION
**Note**: `lib/xchain-helpers` temporarily points to `oldchili/xchain-helpers@lz-gov-bridge`. Once the changes are merged upstream, update the submodule back to `sparkdotfi/xchain-helpers`.

This PR adds support for relaying governance actions to destination chains via Sky's LayerZero Governance Bridge, as an alternative to native bridges and the existing LZ OApp-based bridge.

```
Ethereum                                           Destination Chain
┌──────────┐    ┌──────────────────────┐           ┌─────────────────────────┐    ┌────────────────────┐    ┌──────────┐
│ SubProxy │───>│ GovernanceOAppSender │── LZ ──>  │ GovernanceOAppReceiver  │───>│ LZGovBridgeReceiver│───>│ Executor │
└──────────┘    └──────────────────────┘           └─────────────────────────┘    └────────────────────┘    └──────────┘
```

This PR is/was also reviewed internally here:
https://github.com/oldchili/spark-gov-relay/pull/1